### PR TITLE
Worker commands and tests

### DIFF
--- a/data_dispatcher/ui/ui_worker.py
+++ b/data_dispatcher/ui/ui_worker.py
@@ -1,4 +1,4 @@
-import sys, time
+import sys, time, json
 from .ui_lib import to_did, from_did, pretty_json
 from .cli import CLI, CLICommand, InvalidOptions, InvalidArguments
 from data_dispatcher.api import NotFoundError
@@ -34,7 +34,7 @@ class NextFileCommand(CLICommand):
             if json_out:
                 reply["replicas"] = sorted(reply["replicas"].values(), key=lambda r: 1000000 if r.get("preference") is None else r["preference"])
                 with open(json_out, "w") as jo:
-                    json.dump(reply, jo)
+                    json.dump(reply, jo, indent=4, sort_keys=True)
         else:
             print("timeout" if reply else "done")
             sys.exit(1)        # timeout
@@ -119,9 +119,7 @@ class ListReservedCommand(CLICommand):
             print(pretty_json(handles))
         else:
             for h in handles:
-                for name, val in h.items():
-                    print(f"{name:10s}: {val}")
-                
+                print(h["namespace"] + ':' + h["name"])
 
 
 WorkerCLI = CLI(

--- a/tests/env.py
+++ b/tests/env.py
@@ -8,11 +8,11 @@ if not production:
     base = os.path.dirname(os.path.dirname(__file__))
     os.environ["PATH"] = f"{base}/data_dispatcher/ui:{os.environ['PATH']}"
 #    os.environ["PYTHONPATH"] = f"{base}:{base}/tests/mocks:{os.environ.get('PYTHONPATH','')}"
-    os.environ["PYTHONPATH"] = f"{base}/data_dispatcher:{os.environ['PYTHONPATH']}"
+#    os.environ["PYTHONPATH"] = f"{base}/data_dispatcher:{os.environ['PYTHONPATH']}"
     sys.path.insert(0,base)
 #    sys.path.insert(0,f"{base}/tests/mocks")
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def env():
     if production:
        hostaport = 'https://metacat.fnal.gov:8143'
@@ -30,11 +30,11 @@ def env():
     print("METACAT_SERVER_URL=", os.environ["METACAT_SERVER_URL"])
     print("DATA_DISPATCHER_URL=", os.environ["DATA_DISPATCHER_URL"])
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def token(env):
     os.system("htgettoken -i hypot -a htvaultprod.fnal.gov ")
     
-@pytest.fixture
+@pytest.fixture(scope='session')
 def auth(token):
     os.system("metacat auth login -m token $USER")
     os.system("ddisp login -m token $USER")


### PR DESCRIPTION
Fixed a couple of the worker commands so they should all be working now:

- The option to specify a worker id in the worker list command now works (fixes #2 )
- The option to mark all files as done or failed in the respective commands work now too.

Also added some more tests and re-ordered some of the existing ones.