### PR TITLE
Project commands

### DIFF
--- a/data_dispatcher/api.py
+++ b/data_dispatcher/api.py
@@ -189,7 +189,7 @@ class DataDispatcherClient(HTTPClient, TokenAuthClientMixin):
             )
         )
         
-    def copy_project(self, project_id, common_attributes={}, project_attributes={}, worker_timeout=None):
+    def copy_project(self, project_id, common_attributes={}, project_attributes={}, worker_timeout=None, idle_timeout=None):
         """Creates new project
         
         Args:
@@ -208,7 +208,8 @@ class DataDispatcherClient(HTTPClient, TokenAuthClientMixin):
                     "project_id":           project_id,
                     "file_attributes":      common_attributes,
                     "project_attributes":   project_attributes,
-                    "worker_timeout":       worker_timeout
+                    "worker_timeout":       worker_timeout,
+                    "idle_timeout":         idle_timeout
                 }
             )
         )

--- a/data_dispatcher/api.py
+++ b/data_dispatcher/api.py
@@ -203,6 +203,28 @@ class DataDispatcherClient(HTTPClient, TokenAuthClientMixin):
         Returns:
             (dict) new project information
         """
+        if worker_timeout == "none" or worker_timeout == "None" or worker_timeout == "no timeout":
+            worker_timeout = "no timeout"
+        elif worker_timeout == None or worker_timeout == "default":
+            worker_timeout = "default"
+        elif worker_timeout is not None:
+            mult = 1
+            if worker_timeout[-1].lower() in "smhd":
+                worker_timeout, unit = worker_timeout[:-1], worker_timeout[-1].lower()
+                mult = {'s':1, 'm':60, 'h':3600, 'd':24*3600}[unit]
+            worker_timeout = float(worker_timeout)*mult
+
+        if idle_timeout == "none" or idle_timeout == "None" or idle_timeout == "no timeout":
+            idle_timeout = "no timeout"
+        elif idle_timeout == None or idle_timeout == "default":
+            idle_timeout = "default"
+        elif idle_timeout is not None:
+            mult = 1
+            if idle_timeout[-1].lower() in "smhd":
+                idle_timeout, unit = idle_timeout[:-1], idle_timeout[-1].lower()
+                mult = {'s':1, 'm':60, 'h':3600, 'd':24*3600}[unit]
+            idle_timeout = float(idle_timeout)*mult
+
         return self.post("copy_project", json.dumps(
                 {   
                     "project_id":           project_id,

--- a/data_dispatcher/db.py
+++ b/data_dispatcher/db.py
@@ -54,6 +54,7 @@ def sanitize(s):
     s = str(s)
     if "'" in s:
         raise ValueError('Invalid value: "%s"' % (s,))
+    return s
 
 class DBObject(HasDB):
     

--- a/data_dispatcher/ui/ui_project.py
+++ b/data_dispatcher/ui/ui_project.py
@@ -166,13 +166,6 @@ class CopyCommand(CLICommand):
     
     def __call__(self, command, client, opts, args):
         project_id = int(args[0])
-        # get timeout defaults from the original project
-        proj_orig = client.get_project(project_id, with_files=False, with_replicas=False)
-        if proj_orig is not None:
-            worker_timeout_orig = proj_orig.get("worker_timeout")
-            idle_timeout_orig = proj_orig.get("idle_timeout")
-        else:
-            print("Project not found")
 
         common_attrs = {}
         if "-a" in opts:
@@ -191,10 +184,10 @@ class CopyCommand(CLICommand):
                 project_attrs = parse_attrs(attr_src)
 
         worker_timeout = opts.get("-w")
-        if worker_timeout is None and worker_timeout_orig is not None:
-            worker_timeout = worker_timeout_orig
+        if worker_timeout is None:
+            worker_timeout = "default"
         elif worker_timeout == "none" or worker_timeout == "None":
-            worker_timeout = None
+            worker_timeout = "no timeout"
         elif worker_timeout is not None:
             mult = 1
             if worker_timeout[-1].lower() in "smhd":
@@ -203,10 +196,10 @@ class CopyCommand(CLICommand):
             worker_timeout = float(worker_timeout)*mult
 
         idle_timeout = opts.get("-t")
-        if idle_timeout is None and idle_timeout_orig is not None:
-            idle_timeout = idle_timeout_orig
+        if idle_timeout is None:
+            idle_timeout = "default"
         elif idle_timeout == "none" or idle_timeout == "None":
-            idle_timeout = None
+            idle_timeout = "no timeout"
         elif idle_timeout is not None:
             mult = 1
             if idle_timeout[-1].lower() in "smhd":
@@ -349,7 +342,7 @@ class ListCommand(CLICommand):
             -j                                          - JSON output
             -u <owner>                                  - filter by owner, default: current user only
                 all         - list projects from all users
-                username    - list projects from username            
+                username    - list projects from username
             -s <state>                                  - filter by state, default: active projects only
                 all        - all projects
                 active     - active projects only

--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -294,6 +294,22 @@ time of the project creation, additional authorized users or roles can be specif
         $ ddisp project create -r production,my_group ...
         $ ddisp project create -u alice,bob -r my_group ...
 
+Project states
+..............
+
+There are five different states that a data dispatcher project can be in: active, done, failed, cancelled, or abandoned.
+
+A project is in the *active* state when there are still files to be processed and it hasn't reached the idle_timeout.
+
+A project is in the *done* state when all of its files have been processed successfully.
+
+A project is in the *failed* state when all of its files have finished processing and at least one has failed permanently.
+
+A project is in the *cancelled* state when it has been cancelled by the user.
+
+A project is in the *abandoned* state after the project is idle for longer than the idle_timeout. It can be activated again.
+
+
 Listing projects
 ................
 
@@ -302,7 +318,19 @@ Listing projects
         $ ddisp project list
             -j                                              - JSON output
             -u <owner>                                      - filter by project owner
-            -a "name1=value1 name2=value2 ..."              - filter by project attributes
+                all         - list projects from all users
+                username    - list projects from username
+            -s <state>                                  - filter by state, default: active projects only
+                all        - all projects
+                active     - active projects only
+                done       - projects that are marked done
+                failed     - projects that are marked failed
+                cancelled  - projects that have been cancelled
+                abandoned  - projects that have timed out
+            -n <not_state>                              - filter out by state, default: abandoned projects
+            -a "name1=value1 name2=value2 ..."          - filter by project attributes
+
+
 
 Viewing projects
 ................
@@ -336,8 +364,8 @@ Searching projects
 
 See :ref:`Searching Projects <SearchQL>` for details on search query language
 
-Copying project
-...............
+Copying projects
+................
 
     .. code-block:: shell
 
@@ -348,7 +376,8 @@ Copying project
           -a @<file.json>                                 - JSON file with file attributes to override
           -a "name=value name=value ..."                  - file attributes to override
   
-          -t <worker timeout>|none                        - worker timeout to override
+          -w (<worker timeout>[s|m|h|d] | none)           - worker timeout to override
+          -t (<idle timeout>[s|m|h|d] | none)             - idle timeout to override
 
           -p (json|pprint|id)                             - print created project info as JSON, 
                                                             pprint or just project id (default)

--- a/docs/worker.rst
+++ b/docs/worker.rst
@@ -26,7 +26,7 @@ Using Python API
   cpu_site = ...
   
   # create DD client object
-  from data_dispatcher import DataDispatcherClient
+  from data_dispatcher.api import DataDispatcherClient
   client = DataDispatcherClient(server_url)
   
   #

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -1,5 +1,6 @@
 import pytest
 import os
+import time
 
 from env import env, token, auth
 
@@ -26,7 +27,7 @@ def test_ddisp_login_token(auth, token):
 
 @pytest.fixture(scope='session')
 def proj_id(auth):
-    with os.popen(f"ddisp project create {test_proj} ", "r") as fin:
+    with os.popen(f"ddisp project create -t 60 {test_proj} ", "r") as fin:
         data = fin.read().strip()
     return data
 
@@ -222,24 +223,42 @@ def test_ddisp_project_copy(auth, proj_id, proj_id_copy):
     assert proj_id_copy != proj_id
     assert type(int(proj_id_copy)) == int
 
-#def test_ddisp_project_activate():
-#    os.system(f"ddisp project activate {proj_id_copy} ")
-#    with os.popen(f"ddisp project show {proj_id_copy} ", "r") as fin:
-#        data = fin.read()
-#    assert data.find("active") > 0
+def test_ddisp_project_copy_default_timeouts(auth, proj_id_copy):
+    # check that the copied project has the same timeouts as the original project
+    with os.popen(f"ddisp project show {proj_id_copy}", "r") as fin:
+        data = fin.read()
+    assert data.find("60.0") >= 0
+    assert data.find("43200.0") >= 0
+
+def test_ddisp_project_idle_timeout(auth, proj_id_copy):
+    # check that the project is active at first
+    with os.popen(f"ddisp project show {proj_id_copy} ", "r") as fin:
+        data = fin.read()
+    assert data.find("active") >= 0
+    # check that the project is marked abandoned after timeout
+    time.sleep(90)
+    with os.popen(f"ddisp project show {proj_id_copy} ", "r") as fin:
+        data = fin.read()
+    assert data.find("abandoned") >= 0
+
+def test_ddisp_project_activate(auth, proj_id_copy):
+    os.system(f"ddisp project activate {proj_id_copy} ")
+    with os.popen(f"ddisp project show {proj_id_copy} ", "r") as fin:
+        data = fin.read()
+    assert data.find("active") >= 0
+
 
 def test_ddisp_project_cancel(auth, proj_id_copy):
     os.system(f"ddisp project cancel {proj_id_copy} ")
     with os.popen(f"ddisp project show {proj_id_copy} ", "r") as fin:
         data = fin.read()
-#        print(data.find("cancelled"))
     assert data.find("cancelled") > 0
 
-# needs to be fixed
-#def test_ddisp_project_delete(auth, proj_id_copy):
-#    with os.popen(f"ddisp project delete {proj_id_copy} ", "r") as fin:
-#        data = fin.read()
-#    assert
+def test_ddisp_project_delete(auth, proj_id_copy):
+    os.system(f"ddisp project delete {proj_id_copy} ")
+    with os.popen(f"ddisp project show {proj_id_copy} ", "r") as fin:
+        data = fin.read()
+    assert data.find("not found") >= 0
 
 def test_ddisp_rse_list(auth):
     with os.popen("ddisp rse list", "r") as fin:

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -48,6 +48,18 @@ def test_ddisp_project_list(auth):
     assert data.find("Created") > 0
     assert data.find("State") > 0
 
+def test_ddisp_project_list_options(auth):
+    with os.popen("ddisp project list -s failed") as fin:
+        data = fin.read()
+    assert data.find("failed") >= 0
+    assert data.find("active") < 0
+    assert data.find("abandoned") < 0
+    with os.popen("ddisp project list -s all -n cancelled") as fin:
+        data = fin.read()
+    assert data.find("active") >= 0
+    assert data.find("abandoned") >= 0
+    assert data.find("cancelled") < 0
+
 def test_ddisp_file_show(auth, proj_id):
     with os.popen(f"ddisp file show {proj_id} mengel:a.fcl ", "r") as fin:
         data = fin.read()

--- a/web_server/data_server.py
+++ b/web_server/data_server.py
@@ -178,9 +178,10 @@ class Handler(BaseHandler):
         #print(specs.get("files"))
         db = self.App.db()
         original_project = DBProject.get(db, project_id)
-        worker_timeout = specs.get("worker_timeout", original_project.WorkerTimeout)
         if original_project is None:
             return 404, "Project not found"
+        worker_timeout = specs.get("worker_timeout", original_project.WorkerTimeout)
+        idle_timeout = specs.get("idle_timeout", original_project.IdleTimeout)
         files_updated = []
         for h in original_project.handles():
             attrs = h.Attributes.copy()
@@ -192,7 +193,7 @@ class Handler(BaseHandler):
             ))
         project_attrs = original_project.Attributes.copy()
         project_attrs.update(project_attributes)
-        project = DBProject.create(db, user.Username, attributes=project_attrs, query=original_project.Query, worker_timeout=worker_timeout)
+        project = DBProject.create(db, user.Username, attributes=project_attrs, query=original_project.Query, worker_timeout=worker_timeout, idle_timeout=idle_timeout)
         project.add_files(files_updated)
         project.add_log("event", event="copied", source=project_id, override=dict(
             project=project_attrs, file=file_attributes

--- a/web_server/data_server.py
+++ b/web_server/data_server.py
@@ -352,8 +352,20 @@ class Handler(BaseHandler):
         project_log = (x.as_jsonable() for x in project.handles_log())
         return json.dumps(project_log), "text/json"
 
-    def projects(self, request, relpath, state=None, not_state="abandoned", owner=None, attributes="",
+    def projects(self, request, relpath, state=None, not_state=None, owner=None, attributes="",
                 with_handles="yes", with_replicas="yes", **args):
+        # default to only show projects owned by the current user
+        user, error = self.authenticated_user()
+        if user is None:
+            return 401, error
+        
+        if owner is None:
+            owner = user.Username
+        elif owner == "all":
+            owner = None
+        else:
+            owner = owner
+
         with_handles = with_handles == "yes"
         with_replicas = with_replicas == "yes"
         attributes = urllib.parse.unquote(attributes)

--- a/web_server/data_server.py
+++ b/web_server/data_server.py
@@ -180,8 +180,22 @@ class Handler(BaseHandler):
         original_project = DBProject.get(db, project_id)
         if original_project is None:
             return 404, "Project not found"
+
         worker_timeout = specs.get("worker_timeout", original_project.WorkerTimeout)
         idle_timeout = specs.get("idle_timeout", original_project.IdleTimeout)
+        if type(worker_timeout) == float:
+            worker_timeout = worker_timeout
+        elif worker_timeout == "no timeout":
+            worker_timeout = None
+        elif worker_timeout == "default" or worker_timeout == None:
+            worker_timeout = original_project.WorkerTimeout
+        if type(idle_timeout) == float:
+            idle_timeout = idle_timeout
+        elif idle_timeout == "no timeout":
+            idle_timeout = None
+        elif idle_timeout == "default" or idle_timeout == None:
+            idle_timeout = original_project.IdleTimeout
+
         files_updated = []
         for h in original_project.handles():
             attrs = h.Attributes.copy()


### PR DESCRIPTION
This includes several improvements to the functionality of the project commands:

- Projects can now be deleted (fixes #4).
- Listing projects (this should fix #5)
    - Changed default from listing projects from all users to listing projects from only the current user. Added an option to list projects from all users.
    - Added an option to list projects in all states, and added a -n option to filter out a state.
- Copying projects
    - Added an option to also override the idle timeout. Before it was only possible to override the worker timeout.
    - Fixed the default timeouts so that it will default to the timeout of the original project that is being copied (before it defaulted to None). Also added the possibility to include units like you can when creating a project from scratch.
- Updated the user documentation to include the above changes, and added a description of the project states.
- Added a few tests related to these changes.