### PR TITLE
Reservation security

### DIFF
--- a/data_dispatcher/api.py
+++ b/data_dispatcher/api.py
@@ -482,26 +482,28 @@ class DataDispatcherClient(HTTPClient, TokenAuthClientMixin):
         available = "yes" if available else "no"
         return self.get(f"set_rse_availability?name={name}&available={available}", none_if_not_found=True)
 
-    def file_done(self, project_id, did):
+    def file_done(self, project_id, did, worker_id=None):
         """Notifies Data Dispatcher that the file was successfully processed and should be marked as "done".
         
         Args:
             project_id (int): project id
             did (str): file DID ("<namespace>:<name>")
         """
+        worker_id = worker_id or self.WorkerID
         handle_id = f"{project_id}:{did}"
-        return self.get(f"release?handle_id={handle_id}&failed=no")
+        return self.get(f"release?handle_id={handle_id}&failed=no&worker_id={worker_id}")
 
-    def file_failed(self, project_id, did, retry=True):
+    def file_failed(self, project_id, did, retry=True, worker_id=None):
         """Notifies Data Dispatcher that the file was successfully processed and should be marked as "done".
         
         Args:
             project_id (int): project id
             did (str): file DID ("<namespace>:<name>")
         """
+        worker_id = worker_id or self.WorkerID
         handle_id = f"{project_id}:{did}"
         retry = "yes" if retry else "no"
-        return self.get(f"release?handle_id={handle_id}&failed=yes&retry={retry}")
+        return self.get(f"release?handle_id={handle_id}&failed=yes&retry={retry}&worker_id={worker_id}")
 
     #
     # Deprecated, undocumented, unsupported

--- a/data_dispatcher/ui/ui_main.py
+++ b/data_dispatcher/ui/ui_main.py
@@ -12,6 +12,15 @@ from .ui_worker import WorkerCLI
 from .ui_rse import RSECLI
 from .ui_lib import pretty_json
 
+# =-=-=-=-=-=-=
+# debugging hack  
+# -- uncomment below to get URL's, etc. printed
+#import http.client
+#import logging
+#http.client.HTTPConnection.debuglevel = 1
+#logging.basicConfig(level=logging.DEBUG)
+
+
 class LoginCommand(CLICommand):
     
     Opts = "t:m:"

--- a/tests/test_issue_18.py
+++ b/tests/test_issue_18.py
@@ -1,0 +1,37 @@
+
+import pytest
+import os
+import time
+
+from env import env, token, auth
+from test_commandline import proj_id
+
+test_proj = "files from mengel:gen_cfg"
+
+def test_issue_18(proj_id):
+    # reserve a file as worker_id a, 
+    # then try to release it as worker_id b, should fail
+    # then try to release it as worker_id a, should succeed
+
+    with os.popen("ddisp worker id -n", "r") as fin:
+        wid1 = fin.read().strip()
+    with os.popen("ddisp worker id -n", "r") as fin:
+        wid2 = fin.read().strip()
+    with os.popen(f"ddisp worker id {wid1}", "r") as fin:
+        wid = fin.read().strip()
+    with os.popen(f"ddisp worker next {proj_id} ", "r") as fin:
+        reserved_file = fin.read().strip()
+    # so now we've reserved a file
+    # try to mark it done with a different worker id:
+    with os.popen(f"ddisp worker id {wid2}", "r") as fin:
+        wid = fin.read().strip()
+    with os.popen(f"ddisp worker done {proj_id} {reserved_file} ", "r") as fin:
+        out = fin.read()
+    assert(out.find("wrong worker_id") >= 0)
+
+    # now mark it done with the original worker id:
+    with os.popen(f"ddisp worker id {wid1}", "r") as fin:
+        wid = fin.read().strip()
+    with os.popen(f"ddisp worker done {proj_id} {reserved_file} ", "r") as fin:
+        out = fin.read()
+    assert(len(out.strip()) == 0)

--- a/web_server/data_server.py
+++ b/web_server/data_server.py
@@ -289,16 +289,16 @@ class Handler(BaseHandler):
 
         project_id, namespace, name = DBFileHandle.unpack_id(handle_id)
 
-        handle = project.handle(namespace, name)
-        if worker_id and handle.WorkerID != worker_id:
-            return 403, "Not authorized: wrong worker_id"
-
         project = DBProject.get(db, project_id)
         if project is None:
             return 404, "Project not found"
 
         if not user.is_admin() and user.Username != project.Owner:
             return 403, "Not authorized"
+
+        handle = project.handle(namespace, name)
+        if worker_id and handle.WorkerID != worker_id:
+            return 403, "Not authorized: wrong worker_id"
 
         failed = failed == "yes"
         retry = retry == "yes"

--- a/web_server/data_server.py
+++ b/web_server/data_server.py
@@ -278,7 +278,7 @@ class Handler(BaseHandler):
             }
         return json.dumps(out), "text/json"
 
-    def release(self, request, relpath, handle_id=None, failed="no", retry="yes", **args):
+    def release(self, request, relpath, handle_id=None, failed="no", retry="yes", worker_id='', **args):
         if handle_id is None:
             return 400, "File Handle ID (<project_id>:<namespace>:<name>) must be specified"
         user, error = self.authenticated_user()
@@ -288,6 +288,10 @@ class Handler(BaseHandler):
         db = self.App.db()
 
         project_id, namespace, name = DBFileHandle.unpack_id(handle_id)
+
+        handle = project.handle(namespace, name)
+        if worker_id and handle.WorkerID != worker_id:
+            return 403, "Not authorized: wrong worker_id"
 
         project = DBProject.get(db, project_id)
         if project is None:


### PR DESCRIPTION

This implements #18 -- extends the client to send the worker_id, the server to accept and check it. 
We also add a test to verify it fails if you try to release a reservation with the wrong worker-id. 