### PR TITLE
Worker command and other fixes

### DIFF
--- a/data_dispatcher/ui/ui_main.py
+++ b/data_dispatcher/ui/ui_main.py
@@ -204,16 +204,7 @@ def junk():
 
 def main():
     cli = DDCLI()
-    cli.run(sys.argv, argv0="dd")
+    cli.run(sys.argv, argv0="ddisp")
         
 if __name__ == "__main__":
     main()
-        
-    
-            
-            
-        
-        
-        
-        
-        

--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -445,7 +445,7 @@ This command will show information about a file in a project, including the file
 Listing files
 .............
 
-This command will list all the files in a project, their status, attempts, associated workers, and replica information. They are shown to be available if they have an associated RSE.
+This command will list all the files in a project and show some information about them.
 
     .. code-block:: shell
 
@@ -453,6 +453,18 @@ This command will list all the files in a project, their status, attempts, assoc
                   -j                  -- JSON output
                   -s <handle state>   -- list handles in state
                   -r <rse>            -- list handles with replicas in RSE
+
+An example of the output from this command is below. For each file, it shows the state, number of attempts, associated worker, and replica information. For the replicas, it shows the (number of available replicas)/(total replicas). A file is considered to be available if it can be found in the RSE and is prestaged.
+
+    .. code-block:: shell
+
+	  Status Available  Replicas Attempts   Worker File        
+	-------- --------- --------- -------- -------- ------------
+	 initial       yes    1/1           0          example:b.fcl
+	 initial       yes    1/1           0          example:c.fcl
+	 initial       yes    1/1           0          example:d.fcl
+	 initial       yes    1/1           0          example:e.fcl
+	reserved       yes    1/1           1 635c17c6 example:a.fcl
 
 File states
 ...........
@@ -482,7 +494,7 @@ That is why the Data Dispatcher does not maintain the list of worker ids nor doe
 It is the responsibility of the worker to choose a unique worker id, which has some meaning for the user.
 
 The worker can either assign a worker id explicitly, or have the Data Dispatcher client generate a random worker id.
-In both cases, the worker id will be stored in CWD/.worker_id file and will be used to identify the worker in the future interactions with the
+In both cases, the worker id will be stored in CWD/.data_dispatcher_worker_id file and will be used to identify the worker in the future interactions with the
 Data Dispatcher.
 
     .. code-block:: shell

--- a/tests/test_commandline_json.py
+++ b/tests/test_commandline_json.py
@@ -1,0 +1,162 @@
+import pytest
+import os
+import time
+import json
+
+from env import env, token, auth
+
+test_proj = "files from mengel:gen_cfg"
+
+@pytest.fixture(scope='session')
+def proj_id_json(auth):
+    with os.popen(f"ddisp project create -t 60 -p json {test_proj} ", "r") as fin:
+        data = json.loads(fin.read())["project_id"]
+    return data
+
+def test_ddisp_project_create_json(auth, proj_id_json):
+    assert int(proj_id_json) > 0
+    assert type(int(proj_id_json)) == int
+
+def test_ddisp_project_show_json(auth, proj_id_json):
+    with os.popen(f"ddisp project show -j {proj_id_json}", "r") as fin:
+        data = fin.read()
+    assert data.find("owner") > 0
+    assert data.find("state") > 0
+    assert data.find("created_timestamp") > 0
+    assert json.loads(data)
+
+def test_ddisp_project_list_json(auth):
+    with os.popen("ddisp project list -j", "r") as fin:
+        data = fin.read()
+    assert data.find("owner") > 0
+    assert data.find("created_timestamp") > 0
+    assert data.find("state") > 0
+    assert json.loads(data)
+
+def test_ddisp_project_list_options_json(auth):
+    with os.popen("ddisp project list -j -s failed") as fin:
+        data = fin.read()
+    assert data.find("failed") >= 0
+    assert data.find("abandoned") < 0
+    assert json.loads(data)
+    with os.popen("ddisp project list -j -s all -n cancelled") as fin:
+        data = fin.read()
+    assert data.find("abandoned") >= 0
+    assert data.find("cancelled") < 0
+    assert json.loads(data)
+
+def test_ddisp_file_show_json(auth, proj_id_json):
+    with os.popen(f"ddisp file show -j {proj_id_json} mengel:a.fcl ", "r") as fin:
+        data = fin.read()
+    assert data.find(f"{proj_id_json}") > 0
+    assert data.find("namespace") > 0
+    assert data.find("state") > 0
+    assert json.loads(data)
+
+def test_ddisp_file_list_json(auth, proj_id_json):
+    with os.popen(f"ddisp file list -j {proj_id_json} ", "r") as fin:
+        data = fin.read()
+    assert data.find("state") > 0
+    assert data.find("replicas") > 0
+    assert data.find("name") > 0
+    assert json.loads(data)
+
+def test_ddisp_file_list_rse_json(auth, proj_id_json):
+    with os.popen(f"ddisp file list -j -r FNAL_DCACHE_DISK_TEST {proj_id_json} ", "r") as fin:
+        data = fin.read()
+    assert data.find("a.fcl") > 0
+    assert json.loads(data)
+    with os.popen(f"ddisp file list -j -r TEST {proj_id_json} ", "r") as fin:
+        data = fin.read()
+    assert data.find("a.fcl") < 0
+
+@pytest.fixture(scope='session')
+def next_file_json(auth, proj_id_json):
+    with os.popen(f"ddisp worker next -j {proj_id_json} ", "r") as fin:
+        data = json.loads(fin.read())
+        did = data["namespace"] + ":" + data["name"]
+    return did
+
+def test_ddisp_worker_next(auth, next_file_json):
+    assert len(next_file_json) > 0
+
+def test_ddisp_worker_list_json(auth, proj_id_json):
+    with os.popen(f"ddisp worker list -j {proj_id_json} ", "r") as fin:
+        data = fin.read()
+    assert data.find("project_id") >= 0
+    assert data.find("worker_id") >= 0
+    assert data.find("namespace") >= 0
+    assert json.loads(data)
+
+def test_ddisp_worker_list_w_json(auth, proj_id_json):
+    with os.popen("ddisp worker id", "r") as fin:
+        wid = fin.read().strip()
+    with os.popen(f"ddisp worker list -j -w {wid} {proj_id_json} ", "r") as fin:
+        data = fin.read()
+    assert data.find("namespace") >= 0
+    assert data.find("project_id") >= 0
+    assert data.find("worker_id") >= 0
+    assert json.loads(data)
+
+def test_ddisp_project_show_state_json(auth, proj_id_json):
+    with os.popen(f"ddisp project show -j -f initial {proj_id_json}", "r") as fin:
+        data = fin.read()
+    assert data.find("initial") >= 0
+    assert data.find("failed") < 0
+    assert json.loads(data)
+    with os.popen(f"ddisp project show -j -f done {proj_id_json}", "r") as fin:
+        data = fin.read()
+    assert json.loads(data)
+    data = json.loads(data)
+    assert data["file_handles"] == []
+    with os.popen(f"ddisp project show -j -f test {proj_id_json}", "r") as fin:
+        data = fin.read()
+    assert data.find("Invalid file state") >= 0
+
+def test_ddisp_file_list_state_json(auth, proj_id_json):
+    with os.popen(f"ddisp file list -j -s initial {proj_id_json} ", "r") as fin:
+        data = fin.read()
+    assert json.loads(data)
+    assert data.find("initial") > 0
+    with os.popen(f"ddisp file list -j -s reserved {proj_id_json} ", "r") as fin:
+        data = fin.read()
+    assert data.find("reserved") > 0
+    assert data.find("initial") < 0
+
+@pytest.fixture(scope='session')
+def proj_id_copy_json(auth, proj_id_json):
+    with os.popen(f"ddisp project copy -p json {proj_id_json} ", "r") as fin:
+        data = json.loads(fin.read())["project_id"]
+    return data
+
+def test_ddisp_project_copy_json(auth, proj_id_json, proj_id_copy_json):
+    assert proj_id_copy_json != proj_id_json
+    assert type(int(proj_id_copy_json)) == int
+
+def test_ddisp_project_activate_json(auth, proj_id_copy_json):
+    with os.popen(f"ddisp project activate -j {proj_id_copy_json} ") as fin:
+        data = fin.read()
+    assert json.loads(data)
+    assert data.find("active") >= 0
+
+def test_ddisp_project_cancel_json(auth, proj_id_copy_json):
+    with os.popen(f"ddisp project cancel -j {proj_id_copy_json} ") as fin:
+        data = fin.read()
+    assert json.loads(data)
+    assert data.find("cancelled") > 0
+
+def test_ddisp_rse_list_json(auth):
+    with os.popen("ddisp rse list -j", "r") as fin:
+        data = fin.read()
+    assert json.loads(data)
+    assert data.find("name") >= 0
+    assert data.find("description") >= 0
+
+def test_ddisp_rse_show_json(auth):
+    with os.popen("ddisp rse show -j FNAL_DCACHE_DISK_TEST", "r") as fin:
+        data = fin.read()
+    assert json.loads(data)
+    assert data.find("name") >= 0
+    assert data.find("is_available") >= 0
+
+

--- a/tests/test_issue_18.py
+++ b/tests/test_issue_18.py
@@ -25,7 +25,7 @@ def test_issue_18(proj_id):
     # try to mark it done with a different worker id:
     with os.popen(f"ddisp worker id {wid2}", "r") as fin:
         wid = fin.read().strip()
-    with os.popen(f"ddisp worker done {proj_id} {reserved_file} ", "r") as fin:
+    with os.popen(f"ddisp worker done {proj_id} {reserved_file} 2>&1", "r") as fin:
         out = fin.read()
     assert(out.find("wrong worker_id") >= 0)
 

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -1,0 +1,35 @@
+import pytest
+import os
+import time
+
+from env import env, token, auth
+
+test_proj = "files from mengel:gen_cfg"
+
+@pytest.fixture(scope='session')
+def proj_id(auth):
+    with os.popen(f"ddisp project create -t 180 -w 100 {test_proj} ", "r") as fin:
+        data = fin.read().strip()
+    return data
+
+def test_ddisp_worker_timeout(auth, proj_id):
+    with os.popen(f"ddisp worker next {proj_id} ", "r") as fin:
+        file = fin.read().strip()
+    with os.popen(f"ddisp file list {proj_id} | grep {file} 2>&1", "r") as fin:
+        data = fin.read()
+    assert data.find("reserved") >= 0
+    time.sleep(125)
+    with os.popen(f"ddisp file list {proj_id} | grep {file} ", "r") as fin:
+        data = fin.read()
+    assert data.find("initial") >= 0
+
+def test_ddisp_project_idle_timeout(auth, proj_id):
+    # check that the project is active at first
+    with os.popen(f"ddisp project show {proj_id} ", "r") as fin:
+        data = fin.read()
+    assert data.find("active") >= 0
+    # check that the project is marked abandoned after timeout
+    time.sleep(240)
+    with os.popen(f"ddisp project show {proj_id} ", "r") as fin:
+        data = fin.read()
+    assert data.find("abandoned") >= 0


### PR DESCRIPTION
- Fixed #33 - the json output option of the worker next command now works.
- Added an option to the worker commands to include the worker id (fixes #31 )
- Trying again to make the help messages print "ddisp" instead of "dd"
- Fixed the filtering by file state in the project show command when using the json option
- Fixed the location of the data dispatcher worker file in the help message and the documentation, and added some documentation to explain the output of the file information (fixes #32 )
- Added tests to check the json option for all commands that use it, added a test for the worker timeout (moved the timeout tests to its own file), fixed some other tests since the output of project show changed