### PR TITLE
Fix #35

### DIFF
--- a/data_dispatcher/ui/ui_lib.py
+++ b/data_dispatcher/ui/ui_lib.py
@@ -61,7 +61,7 @@ def print_handles(handles, print_replicas):
             file_available,
             "%4d/%-4d" % (available_replicas, nreplicas),
             f["attempts"],
-            f["worker_id"],
+            f["worker_id"] if f["worker_id"] else "-",
             "%s:%s" % (f["namespace"], f["name"])
         )
         if print_replicas:


### PR DESCRIPTION
Print a dash in the worker column if there is no woker_id when listing project handles.