### PR TITLE
File timeouts

### DIFF
--- a/data_dispatcher/ui/ui_lib.py
+++ b/data_dispatcher/ui/ui_lib.py
@@ -52,7 +52,7 @@ def print_handles(handles, print_replicas):
         available_replicas = 0 if rlist is None else len([r for r in rlist.values() if r["available"] and r["rse_available"]])
         nreplicas = 0 if rlist is None else len(rlist)
         state = f["state"]
-        timeouts = f.get('attributes')["timeouts"]
+        timeouts = f.get('attributes', {}).get("timeouts", 0)
         if available_replicas > 0:
             file_available = "yes"
         else:

--- a/data_dispatcher/ui/ui_lib.py
+++ b/data_dispatcher/ui/ui_lib.py
@@ -31,7 +31,7 @@ def print_handles(handles, print_replicas):
         "failed":       4
     }
     
-    table = Table("Status", "Available", "Replicas", "Attempts", "Worker", 
+    table = Table("Status", "Available", "Replicas", "Attempts", "Timeouts", "Worker", 
             Column("File" + (" / RSE, avlbl, URL" if print_replicas else ""),
                 left=True)
     )
@@ -52,6 +52,7 @@ def print_handles(handles, print_replicas):
         available_replicas = 0 if rlist is None else len([r for r in rlist.values() if r["available"] and r["rse_available"]])
         nreplicas = 0 if rlist is None else len(rlist)
         state = f["state"]
+        timeouts = f.get('attributes')["timeouts"]
         if available_replicas > 0:
             file_available = "yes"
         else:
@@ -61,6 +62,7 @@ def print_handles(handles, print_replicas):
             file_available,
             "%4d/%-4d" % (available_replicas, nreplicas),
             f["attempts"],
+            timeouts,
             f["worker_id"] if f["worker_id"] else "-",
             "%s:%s" % (f["namespace"], f["name"])
         )

--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -283,6 +283,14 @@ When the worker gets next file to process, the JSON representation of file infor
           "worker_id": "fnpc123_pid4563"
         }
 
+Special project attributes
+..........................
+There are a couple of special project attributes that cause different behavior in data dispatcher.
+
+Setting *virtual=True* will prevent data dispatcher from looking for the files in rucio. The default is False.
+
+Setting *retry_on_timeout=False* will cause the project's files that timed out to go to the failed state instead of back to the initial state. The default is True.
+
 Project ownership and use authorization
 .......................................
 
@@ -456,17 +464,17 @@ This command will list all the files in a project and show some information abou
                   -s <handle state>   -- list handles in state
                   -r <rse>            -- list handles with replicas in RSE
 
-An example of the output from this command is below. For each file, it shows the state, number of attempts, associated worker, and replica information. For the replicas, it shows the (number of available replicas)/(total replicas). A file is considered to be available if it can be found in the RSE and is prestaged.
+An example of the output from this command is below. For each file, it shows the state, number of attempts, number of times it timed out, the associated worker, and replica information. For the replicas, it shows the (number of available replicas)/(total replicas). A file is considered to be available if it can be found in the RSE and is prestaged.
 
     .. code-block:: shell
 
-	  Status Available  Replicas Attempts   Worker File        
-	-------- --------- --------- -------- -------- ------------
-	 initial       yes    1/1           0          example:b.fcl
-	 initial       yes    1/1           0          example:c.fcl
-	 initial       yes    1/1           0          example:d.fcl
-	 initial       yes    1/1           0          example:e.fcl
-	reserved       yes    1/1           1 635c17c6 example:a.fcl
+	  Status Available  Replicas Attempts Timeouts Worker    File        
+	-------- --------- --------- -------- -------- -------- ------------
+	 initial       yes    1/1           0        0          example:b.fcl
+	 initial       yes    1/1           0        0          example:c.fcl
+	 initial       yes    1/1           0        0          example:d.fcl
+	 initial       yes    1/1           1        1          example:e.fcl
+	reserved       yes    1/1           1        0 635c17c6 example:a.fcl
 
 File states
 ...........

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -19,9 +19,14 @@ def test_ddisp_worker_timeout(auth, proj_id):
         data = fin.read()
     assert data.find("reserved") >= 0
     time.sleep(125)
+    # the file should go back to the initial state after timing out
     with os.popen(f"ddisp file list {proj_id} | grep {file} ", "r") as fin:
         data = fin.read()
     assert data.find("initial") >= 0
+    # the file should now have an attribute with the number of timeouts
+    with os.popen(f"ddisp file show {proj_id} {file}", "r") as fin:
+        data = fin.read()
+    assert data.find("timeouts") >= 0
 
 def test_ddisp_project_idle_timeout(auth, proj_id):
     # check that the project is active at first
@@ -33,3 +38,18 @@ def test_ddisp_project_idle_timeout(auth, proj_id):
     with os.popen(f"ddisp project show {proj_id} ", "r") as fin:
         data = fin.read()
     assert data.find("abandoned") >= 0
+
+@pytest.fixture(scope='session')
+def proj_id_noretry(auth):
+    with os.popen(f"ddisp project create -w 100 -A 'retry_on_timeout=False' {test_proj} ", "r") as fin:
+        data = fin.read().strip()
+    return data
+
+def test_no_retry_timeouts(auth, proj_id_noretry):
+    with os.popen(f"ddisp worker next {proj_id_noretry} ", "r") as fin:
+        file = fin.read().strip()
+    time.sleep(125)
+    # this time the file should go to the failed state after timing out
+    with os.popen(f"ddisp file list {proj_id_noretry} ", "r") as fin:
+        data = fin.read()
+    assert data.find("failed") >= 0


### PR DESCRIPTION
Added a file attribute <code>{'timeouts': N}</code> that contains the number of times the file timed out, and added a corresponding column to the display table. Also added a project attribute <code>{'retry_on_timeout': True/False}</code> that sends the file to the failed state if False. The default behavior is still True.

This should close #34 