### PR TITLE
fix json output of worker next

### DIFF
--- a/data_dispatcher/ui/ui_worker.py
+++ b/data_dispatcher/ui/ui_worker.py
@@ -10,7 +10,7 @@ class NextFileCommand(CLICommand):
     Usage = """[options] <project_id> -- get next available file
              -w <worker id>     -- specify worker id
              -c <cpu site>      -- choose the file according to the CPU/RSE proximity map for the CPU site
-             -j <json file>     -- write reserved file information into a JSON file
+             -j                 -- JSON output
              -t <timeout>       -- wait for next file until "timeout" seconds, 
                                    otherwise, wait until the project finishes
     """
@@ -30,11 +30,11 @@ class NextFileCommand(CLICommand):
             sys.exit(1)
 
         if isinstance(reply, dict):
-            print("%s:%s" % (reply["namespace"], reply["name"]))
             if json_out:
                 reply["replicas"] = sorted(reply["replicas"].values(), key=lambda r: 1000000 if r.get("preference") is None else r["preference"])
-                with open(json_out, "w") as jo:
-                    json.dump(reply, jo, indent=4, sort_keys=True)
+                print(pretty_json(reply))
+            else:
+                print("%s:%s" % (reply["namespace"], reply["name"]))
         else:
             resp = "timeout" if reply else "done"
             if json_out:


### PR DESCRIPTION
This fixes the bad file descriptor error seen when running "ddisp worker next -j". It originally expected to be provided a file name for the json output but that has been removed in order to match the rest of the ddisp commands.