### PR TITLE
New RSE commands

### DIFF
--- a/data_dispatcher/api.py
+++ b/data_dispatcher/api.py
@@ -477,18 +477,107 @@ class DataDispatcherClient(HTTPClient, TokenAuthClientMixin):
         return self.get(f"get_rse?name={name}", none_if_not_found=True)
 
     def set_rse_availability(self, name, available):
-        """Changes RSE availability flag. The user must be an admin.
-
-        Args:
-            name (str): RSE name
-            available (boolean): RSE availability
-
-        Returns:
-            dictionary with updated RSE information or None if not found
+        """"
+        Deprecated. Please use update_rse instead.
         """
 
-        available = "yes" if available else "no"
-        return self.get(f"set_rse_availability?name={name}&available={available}", none_if_not_found=True)
+#        """Changes RSE availability flag. The user must be an admin.
+
+#        Args:
+#            name (str): RSE name
+#            available (boolean): RSE availability
+
+#        Returns:
+#            dictionary with updated RSE information or None if not found
+#        """
+
+#        available = "yes" if available else "no"
+#        return self.get(f"set_rse_availability?name={name}&available={available}", none_if_not_found=True)
+
+    def create_rse(self, name, description, is_enabled=True, is_available=True, is_tape=False, pin_url=None, poll_url=None, remove_prefix=None, add_prefix=None, pin_prefix=None, preference=None, interface=None):
+        """Creates new RSE
+
+        Parameters
+        ----------
+        name (string): Name of RSE to be created
+        description (string): Description of new RSE (optional)
+        is_enabled (boolean): Whether the RSE is enabled
+        is_available (boolean): Whether the RSE is available
+        is_tape (boolean): Whether the RSE is tape or not
+        pin_url (string): Pin URL for native, discovery URL for WLCG
+        poll_url (string): Poll URL for native, not used for WLCG
+        remove_prefix (string): Prefix to remove for URL to path conversion (optional)
+        add_prefix (string): Prefix to add for URL to path conversion (optional)
+        pin_prefix (string): Pin prefix (optional)
+        preference (integer): Preference of RSE
+        interface (string): Either native or WLCG
+
+        Returns
+        -------
+        dict : new RSE information
+        """
+
+        return self.post("create_rse", json.dumps(
+            {
+                "name":           name,
+                "description":    description,
+                "is_enabled":     is_enabled,
+                "is_available":   is_available,
+                "is_tape":        is_tape,
+                "pin_url":        pin_url,
+                "poll_url":       poll_url,
+                "remove_prefix":  remove_prefix,
+                "add_prefix":     add_prefix,
+                "pin_prefix":     pin_prefix,
+                "preference":     preference,
+                "interface":      interface
+            }
+          )
+        )
+
+    def update_rse(self, name, description, is_enabled=None, is_available=None, is_tape=None, pin_url=None, poll_url=None, remove_prefix=None, add_prefix=None, pin_prefix=None, preference=None, interface=None):
+        """Update RSE settings. User must be an admin.
+
+        Parameters
+        ----------
+        name (string): Name of RSE to be created
+        description (string): Description of new RSE (optional)
+        is_enabled (boolean): Whether the RSE is enabled
+        is_available (boolean): Whether the RSE is available
+        is_tape (boolean): Whether the RSE is tape or not
+        pin_url (string): Pin URL for native, discovery URL for WLCG
+        poll_url (string): Poll URL for native, not used for WLCG
+        remove_prefix (string): Prefix to remove for URL to path conversion (optional)
+        add_prefix (string): Prefix to add for URL to path conversion (optional)
+        pin_prefix (string): Pin prefix (optional)
+        preference (integer): Preference of RSE
+        interface (string): Either native or WLCG
+
+        Returns
+        -------
+        dict : updated RSE information
+        """
+
+        return self.post("update_rse", json.dumps(
+            {
+                "Name":           name,
+                "Description":    description,
+                "Enabled":     is_enabled,
+                "Available":   is_available,
+                "Tape":        is_tape,
+                "PinURL":        pin_url,
+                "PollURL":       poll_url,
+                "RemovePrefix":  remove_prefix,
+                "AddPrefix":     add_prefix,
+                "PinPrefix":     pin_prefix,
+                "Preference":     preference,
+                "Type":      interface
+            }
+          )
+        )
+
+    def delete_rse(self, name):
+        return self.get(f"delete_rse?name={name}")
 
     def file_done(self, project_id, did, worker_id=None):
         """Notifies Data Dispatcher that the file was successfully processed and should be marked as "done".

--- a/data_dispatcher/ui/ui_rse.py
+++ b/data_dispatcher/ui/ui_rse.py
@@ -3,15 +3,61 @@ from .ui_lib import pretty_json
 from .cli import CLI, CLICommand, InvalidOptions, InvalidArguments
 from .cli.tabular import Table, Column
 
-Usage = """
-show rse [-j] <name>                        - show RSE information
-set rse -a (yes|no) <name>                  - set RSE availability (requires admin privileges)
+#Usage = """
+#show rse [-j] <name>                        - show RSE information
+#set rse -a (yes|no) <name>                  - set RSE availability (requires admin privileges)
+#"""
+
+RSEOpts = "e:d:t:a:o:m:l:i:u:p:f:j"
+RSEUsage = """
+
+-e (True|False)                           -- the RSE should be enabled
+-d <description>                          -- description of RSE
+-t (True|False)                           -- the RSE is tape
+-a (True|False)                           -- the RSE should be available
+-o <preference>                           -- preference of RSE (integer)
+
+-m <prefix>                               -- add prefix
+-l <prefix>                               -- remove prefix
+
+For dCache RSEs only:
+-i (wlcg|native)                          -- interface
+-u <url>                                  -- pin/discovery url
+-p <prefix>                               -- pin prefix
+-f <url>                                  -- poll url (only for native, not used for wlcg)
+
+-j                                        -- json output
+
 """
+def bool_input(opt):
+    if opt in ("True", "true"):
+        val = True
+    elif opt in ("False", "false"):
+        val = False
+    else:
+        val = None
+    return val
+
+def rse_input(opts):
+    params = {
+        'description': opts.get("-d"),
+        'is_enabled': bool_input(opts.get("-e")),
+        'is_tape': bool_input(opts.get("-t")),
+        'is_available': bool_input(opts.get("-a")),
+        'preference': int(opts.get("-o")) if opts.get("-o") is not None else None,
+        'add_prefix': opts.get("-m"),
+        'remove_prefix': opts.get("-l"),
+        'interface': opts.get("-i"),
+        'pin_url': opts.get("-u"),
+        'pin_prefix': opts.get("-p"),
+        'poll_url': opts.get("-f")
+    }
+    return params
 
 class ShowCommand(CLICommand):
     
     Opts = "j"
-    Usage = """[-j] <rse>
+    Usage = """[-j] <rse>                    -- show RSE information
         -j          -- JSON output
     """
     MinArgs = 1
@@ -36,20 +82,22 @@ class ShowCommand(CLICommand):
 
 class SetAvailability(CLICommand):
 
-    Usage = "(up|down) <rse>"
-    MinArgs = 2
+    Usage = "Deprecated. Please use ddisp rse update instead."
+
+    #Usage = "(up|down) <rse>                 - set RSE availability (requires admin privileges)"
+    #MinArgs = 2
     
-    def __call__(self, command, client, opts, args):
-        up_down, name = args
-        if up_down not in ("up", "down"):
-            print(Usage)
-            sys.exit(2)
-        return client.set_rse_availability(name, up_down == "up")
+    #def __call__(self, command, client, opts, args):
+    #    up_down, name = args
+    #    if up_down not in ("up", "down"):
+    #        print(Usage)
+    #        sys.exit(2)
+    #    return client.set_rse_availability(name, up_down == "up")
     
 class ListTabularCommand(CLICommand):
 
     Opts = "j"
-    Usage = """[-j]             -- JSON output"""
+    Usage = """[-j]                          -- JSON output"""
 
     def __call__(self, command, client, opts, args):
         rses = sorted(client.list_rses(), key=lambda r: r["name"])
@@ -57,7 +105,7 @@ class ListTabularCommand(CLICommand):
             print(pretty_json(rses))
         elif rses:
             table = Table(Column("Name", min_width=30, left=True), 
-                "Tape", "Status", 
+                "Tape", "Status", "Enabled", 
                 Column("Description", min_width=60, left=True)
             )
 
@@ -65,13 +113,14 @@ class ListTabularCommand(CLICommand):
                 table.add_row(rse["name"],
                     "tape" if rse["is_tape"] else "",
                     "up" if rse["is_available"] else "down",
+                    "yes" if rse["is_enabled"] else "no",
                     rse["description"])
             table.print()
     
 class ListCommand(CLICommand):
 
     Opts = "j"
-    Usage = """[-j]             -- JSON output"""
+    Usage = """[-j]                         -- JSON output"""
 
     def __call__(self, command, client, opts, args):
         rses = sorted(client.list_rses(), key=lambda r: r["name"])
@@ -91,11 +140,74 @@ class ListCommand(CLICommand):
                     rse["description"]
                 ))
             print("%s" % ("-"*105,)) 
+
+class CreateCommand(CLICommand):
+
+    MinArgs = 1
+    Opts = RSEOpts
+    Usage = "[options] <rse_name>          -- create RSE" + RSEUsage
+
+    def __call__(self, command, client, opts, args):
+        p = rse_input(opts)
+        name = args[0]
+        rse_info = client.create_rse(name, p["description"], p["is_enabled"], p["is_available"], p["is_tape"], p["pin_url"], p["poll_url"], p["remove_prefix"], p["add_prefix"], p["pin_prefix"], p["preference"], p["interface"])
+
+        if "-j" in opts:
+            print(pretty_json(rse_info))
+        else:
+            print("RSE:           ", name)
+            print("Preference:    ", rse_info["preference"])
+            print("Tape:          ", "yes" if rse_info["is_tape"] else "no")
+            print("Available:     ", "yes" if rse_info["is_available"] else "no")
+            print("Pin URL:       ", rse_info.get("pin_url") or "")
+            print("Poll URL:      ", rse_info.get("poll_url") or "")
+            print("Remove prefix: ", rse_info["remove_prefix"])
+            print("Add prefix:    ", rse_info["add_prefix"])
+
+        
+class UpdateCommand(CLICommand):
+
+    Opts = RSEOpts
+    Usage = "[options] <rse_name>        -- update RSE" + RSEUsage
+
+    MinArgs = 1
+
+    def __call__(self, command, client, opts, args):
+        name = args[0]
+        updates = rse_input(opts)
+
+        #print(name, updates)
+        rse_info = client.update_rse(name, **updates)
+        
+        if "-j" in opts:
+            print(pretty_json(rse_info))
+        else:
+            print("RSE:           ", name)
+            print("Preference:    ", rse_info["preference"])
+            print("Tape:          ", "yes" if rse_info["is_tape"] else "no")
+            print("Available:     ", "yes" if rse_info["is_available"] else "no")
+            print("Pin URL:       ", rse_info.get("pin_url") or "")
+            print("Poll URL:      ", rse_info.get("poll_url") or "")
+            print("Remove prefix: ", rse_info["remove_prefix"])
+            print("Add prefix:    ", rse_info["add_prefix"])
+
+class DeleteCommand(CLICommand):
+
+    Usage = """<rse_name>                    -- remove RSE"""
+    MinArgs = 1
+
+    def __call__(self, command, client, opts, args):
+        rse_name = args[0]
+        client.delete_rse(rse_name)
+
     
 RSECLI = CLI(
     "list",         ListTabularCommand(),
-    "set",          SetAvailability(),
-    "show",         ShowCommand()
+    "show",         ShowCommand(),
+    "create",       CreateCommand(),
+    "update",       UpdateCommand(),
+    "delete",       DeleteCommand(),
+    "set",          SetAvailability()
 )        
     
     

--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -674,14 +674,14 @@ Listing known RSEs
         ]
         
         $ ddisp rse list
-        Name                                     Pref Tape Status Description
-        --------------------------------------------------------------------------------------------------------------
-        FNAL_DCACHE                                 0 tape     up FNAL dCache
-        FNAL_DCACHE_PERSISTENT                      0 tape     up 
-        FNAL_DCACHE_STAGING                         0 tape     up 
-        FNAL_DCACHE_TEST                            0 tape     up 
-        LANCASTER                                   0          up 
-        TEST_RSE                                    0          up Test RSE
+        Name                           Tape Status Enabled Description                                                 
+        ------------------------------ ---- ------ ------- ------------------------------------------------------------
+        FNAL_DCACHE                    tape     up     yes FNAL dCache
+        FNAL_DCACHE_PERSISTENT         tape     up     yes 
+        FNAL_DCACHE_STAGING            tape     up     yes  
+        FNAL_DCACHE_TEST               tape     up     yes  
+        LANCASTER                               up     yes  
+        TEST_RSE                                up     yes Test RSE
         --------------------------------------------------------------------------------------------------------------
         
         
@@ -713,15 +713,40 @@ Showing information about particular RSE
           "remove_prefix": ""
         }
 
-Changing RSE availability
-.........................
+Creating an RSE
+...............
 
-This command requires admin privileges.
+Add a new RSE in data dispatcher. This command requires admin privileges.
 
     .. code-block:: shell
 
-        $ ddisp rse set -a down FNAL_DCACHE
-        $ ddisp rse show FNAL_DCACHE
+        $ ddisp rse create [options] <rse_name>          -- create RSE
+  
+          -e (True|False)                           -- the RSE should be enabled
+          -d <description>                          -- description of RSE
+          -t (True|False)                           -- the RSE is tape
+          -a (True|False)                           -- the RSE should be available
+          -o <preference>                           -- preference of RSE (integer)
+  
+          -m <prefix>                               -- add prefix
+          -l <prefix>                               -- remove prefix
+  
+          For dCache RSEs only:
+          -i (wlcg|native)                          -- interface
+          -u <url>                                  -- pin/discovery url
+          -p <prefix>                               -- pin prefix
+          -f <url>                                  -- poll url (only for native, not used for wlcg)
+  
+          -j                                        -- json output
+
+Changing RSE attributes
+.......................
+
+Update any of the parameters of an RSE. This command requires admin privileges. To update the availability:
+
+    .. code-block:: shell
+
+        $ ddisp rse update -a False FNAL_DCACHE
         RSE:            FNAL_DCACHE
         Preference:     0
         Tape:           yes
@@ -729,5 +754,14 @@ This command requires admin privileges.
         ...
         
 When an RSE is unavailable (down), replicas in this RSE are considered unavailable even if this is a disk RSE or they are known to be staged in a tape RSE.
+
+Deleting an RSE
+...............
+
+Remove an RSE from data dispatcher. This command requires admin privileges.
+
+    .. code-block:: shell
+
+        $ ddisp rse delete <rse_name>                    -- remove RSE
 
 

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -233,7 +233,6 @@ def test_ddisp_project_activate(auth, proj_id_copy):
         data = fin.read()
     assert data.find("active") >= 0
 
-
 def test_ddisp_project_cancel(auth, proj_id_copy):
     os.system(f"ddisp project cancel {proj_id_copy} ")
     with os.popen(f"ddisp project show {proj_id_copy} ", "r") as fin:
@@ -253,8 +252,22 @@ def test_ddisp_rse_list(auth):
     assert data.find("Status") >= 0
     assert data.find("Description") >= 0
 
-#def test_ddisp_rse_set():
+def test_ddisp_rse_create(auth):
+    with os.popen(f"ddisp rse create -a True -d 'fake rse for testing' -o 2 TESTING", "r") as fin:
+        data = fin.read()
+    assert data.find("TESTING") >= 0
+    assert data.find("Available") >= 0
 
+def test_ddisp_rse_update(auth):
+    with os.popen(f"ddisp rse update -m testprefix TESTING", "r") as fin:
+        data = fin.read()
+    assert data.find("testprefix") >= 0
+
+def test_ddisp_rse_delete(auth):
+    os.system(f"ddisp rse delete TESTING")
+    with os.popen("ddisp rse list", "r") as fin:
+        data = fin.read()
+    assert data.find("TESTING") < 0
 
 def test_ddisp_rse_show(auth):
     with os.popen("ddisp rse show FNAL_DCACHE_DISK_TEST", "r") as fin:

--- a/tests/test_commandline_json.py
+++ b/tests/test_commandline_json.py
@@ -159,4 +159,18 @@ def test_ddisp_rse_show_json(auth):
     assert data.find("name") >= 0
     assert data.find("is_available") >= 0
 
+def test_ddisp_rse_create_json(auth):
+    with os.popen("ddisp rse create -a True -d 'fake rse for testing' -o 2 -j TESTING", "r") as fin:
+        data = fin.read()
+    assert json.loads(data)
+    assert data.find("TESTING") >= 0
+    assert data.find("is_available") >= 0
+
+def test_ddisp_rse_update_json(auth):
+    with os.popen(f"ddisp rse update -m testprefix -j TESTING", "r") as fin:
+        data = fin.read()
+    assert json.loads(data)
+    assert data.find("testprefix") >= 0
+    os.system("ddisp rse delete TESTING")
+
 


### PR DESCRIPTION
Added new commands for managing RSEs from the command line, which was already possible from the GUI. There is now a "ddisp rse create", "ddisp rse update", and "ddisp rse delete". Also modified the "ddisp rse list" command so that it shows the disabled RSEs and added another column to the table to show whether or not they are enabled. This should close #30 